### PR TITLE
Add src/dependencies/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+src/dependencies/


### PR DESCRIPTION
Add the `src/dependencies/` directory to `.gitignore`.