### PR TITLE
Update actions/checkout in GitHub Actions to v4

### DIFF
--- a/.github/workflows/ubuntu22-sanitize.yml
+++ b/.github/workflows/ubuntu22-sanitize.yml
@@ -9,7 +9,7 @@ jobs:
       ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use cmake
         run: |
           mkdir builddebug &&
@@ -22,4 +22,4 @@ jobs:
           cd build &&
           cmake -DIS_UTF8_SANITIZE=ON ..  &&
           cmake --build .   &&
-          ctest -j --output-on-failure -LE explicitonly 
+          ctest -j --output-on-failure -LE explicitonly

--- a/.github/workflows/ubuntu22.yml
+++ b/.github/workflows/ubuntu22.yml
@@ -9,7 +9,7 @@ jobs:
       ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use cmake
         run: |
           mkdir builddebug &&
@@ -22,4 +22,4 @@ jobs:
           cd build &&
           cmake ..  &&
           cmake --build .   &&
-          ctest -j --output-on-failure -LE explicitonly 
+          ctest -j --output-on-failure -LE explicitonly

--- a/.github/workflows/vs17.yml
+++ b/.github/workflows/vs17.yml
@@ -17,7 +17,7 @@ jobs:
           - {gen: Visual Studio 17 2022, arch: x64, shared: OFF}
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Configure
       run: |
         cmake -G "${{matrix.gen}}" -A ${{matrix.arch}} -DBUILD_SHARED_LIBS=${{matrix.shared}} -B build


### PR DESCRIPTION
This updates [actions/checkout](https://github.com/actions/checkout) to v4, it's current version.

Changelog:

> ## v4.1.0
> - Add support for partial checkout filters
>
> ## v4.0.0
> - Support fetching without the --progress option
> - Update to node20

Furthermore, some superfluous whitespace characters are removed at the end of some of those workflow files.