### PR TITLE
Use C style function names instead

### DIFF
--- a/include/is_utf8.h
+++ b/include/is_utf8.h
@@ -6,5 +6,5 @@
 // 99.99% of the inputs are valid UTF-8.
 // Thus the function unconditionally scans the
 // whole input.
-bool is_utf8(const char *src, size_t len);
+extern "C" bool is_utf8(const char *src, size_t len);
 #endif // IS_UTF8

--- a/src/is_utf8.cpp
+++ b/src/is_utf8.cpp
@@ -6748,6 +6748,8 @@ IS_UTF8_UNTARGET_REGION
 
 IS_UTF8_POP_DISABLE_WARNINGS
 
-bool is_utf8(const char *src, size_t len) {
-  return is_utf8_internals::validate_utf8(src, len);
+extern "C" {
+  bool is_utf8(const char *src, size_t len) {
+    return is_utf8_internals::validate_utf8(src, len);
+  }
 }


### PR DESCRIPTION
When trying to embed this library into my rust project, I encountered an issue due to the mangling of function names. In order to be able to better include this library in non-cpp projects, I would like to suggest turning off the mangling of function names by defining the main function as "extern C".