### PR TITLE
fix gcc-14 warnings

### DIFF
--- a/src/is_utf8.cpp
+++ b/src/is_utf8.cpp
@@ -2568,11 +2568,11 @@ template <> struct simd8<bool> : base8<bool> {
     return _mm256_set1_epi8(uint8_t(-(!!_value)));
   }
 
-  is_utf8_really_inline simd8<bool>() : base8() {}
-  is_utf8_really_inline simd8<bool>(const __m256i _value)
+  is_utf8_really_inline simd8() : base8() {}
+  is_utf8_really_inline simd8(const __m256i _value)
       : base8<bool>(_value) {}
   // Splat constructor
-  is_utf8_really_inline simd8<bool>(bool _value) : base8<bool>(splat(_value)) {}
+  is_utf8_really_inline simd8(bool _value) : base8<bool>(splat(_value)) {}
 
   is_utf8_really_inline uint32_t to_bitmask() const {
     return uint32_t(_mm256_movemask_epi8(*this));
@@ -2998,11 +2998,11 @@ template <> struct simd16<bool> : base16<bool> {
     return _mm256_set1_epi16(uint16_t(-(!!_value)));
   }
 
-  is_utf8_really_inline simd16<bool>() : base16() {}
-  is_utf8_really_inline simd16<bool>(const __m256i _value)
+  is_utf8_really_inline simd16() : base16() {}
+  is_utf8_really_inline simd16(const __m256i _value)
       : base16<bool>(_value) {}
   // Splat constructor
-  is_utf8_really_inline simd16<bool>(bool _value)
+  is_utf8_really_inline simd16(bool _value)
       : base16<bool>(splat(_value)) {}
 
   is_utf8_really_inline bitmask_type to_bitmask() const {
@@ -3549,11 +3549,11 @@ template <> struct simd8<bool> : base8<bool> {
     return _mm_set1_epi8(uint8_t(-(!!_value)));
   }
 
-  is_utf8_really_inline simd8<bool>() : base8() {}
-  is_utf8_really_inline simd8<bool>(const __m128i _value)
+  is_utf8_really_inline simd8() : base8() {}
+  is_utf8_really_inline simd8(const __m128i _value)
       : base8<bool>(_value) {}
   // Splat constructor
-  is_utf8_really_inline simd8<bool>(bool _value) : base8<bool>(splat(_value)) {}
+  is_utf8_really_inline simd8(bool _value) : base8<bool>(splat(_value)) {}
 
   is_utf8_really_inline int to_bitmask() const {
     return _mm_movemask_epi8(*this);
@@ -4065,11 +4065,11 @@ template <> struct simd16<bool> : base16<bool> {
     return _mm_set1_epi16(uint16_t(-(!!_value)));
   }
 
-  is_utf8_really_inline simd16<bool>() : base16() {}
-  is_utf8_really_inline simd16<bool>(const __m128i _value)
+  is_utf8_really_inline simd16() : base16() {}
+  is_utf8_really_inline simd16(const __m128i _value)
       : base16<bool>(_value) {}
   // Splat constructor
-  is_utf8_really_inline simd16<bool>(bool _value)
+  is_utf8_really_inline simd16(bool _value)
       : base16<bool>(splat(_value)) {}
 
   is_utf8_really_inline int to_bitmask() const {


### PR DESCRIPTION
This PR fixes the following warnings in gcc 14:
```
[build] ~/is_utf8/src/is_utf8.cpp:2571:36: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
[build]  2571 |   is_utf8_really_inline simd8<bool>() : base8() {}
[build]       |                                    ^
[build] ~/is_utf8/src/is_utf8.cpp:2571:36: note: remove the ‘< >’
[build] ~/is_utf8/src/is_utf8.cpp:2572:36: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
[build]  2572 |   is_utf8_really_inline simd8<bool>(const __m256i _value)
[build]       |                                    ^
[build] ~/is_utf8/src/is_utf8.cpp:2572:36: note: remove the ‘< >’
[build] ~/is_utf8/src/is_utf8.cpp:2575:36: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
[build]  2575 |   is_utf8_really_inline simd8<bool>(bool _value) : base8<bool>(splat(_value)) {}
[build]       |                                    ^
[build] ~/is_utf8/src/is_utf8.cpp:2575:36: note: remove the ‘< >’
[build] ~/is_utf8/src/is_utf8.cpp:3001:37: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
[build]  3001 |   is_utf8_really_inline simd16<bool>() : base16() {}
[build]       |                                     ^
[build] ~/is_utf8/src/is_utf8.cpp:3001:37: note: remove the ‘< >’
[build] ~/is_utf8/src/is_utf8.cpp:3002:37: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
[build]  3002 |   is_utf8_really_inline simd16<bool>(const __m256i _value)
[build]       |                                     ^
[build] ~/is_utf8/src/is_utf8.cpp:3002:37: note: remove the ‘< >’
[build] ~/is_utf8/src/is_utf8.cpp:3005:37: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
[build]  3005 |   is_utf8_really_inline simd16<bool>(bool _value)
[build]       |                                     ^
[build] ~/is_utf8/src/is_utf8.cpp:3005:37: note: remove the ‘< >’
[build] ~/is_utf8/src/is_utf8.cpp:3552:36: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
[build]  3552 |   is_utf8_really_inline simd8<bool>() : base8() {}
[build]       |                                    ^
[build] ~/is_utf8/src/is_utf8.cpp:3552:36: note: remove the ‘< >’
[build] ~/is_utf8/src/is_utf8.cpp:3553:36: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
[build]  3553 |   is_utf8_really_inline simd8<bool>(const __m128i _value)
[build]       |                                    ^
[build] ~/is_utf8/src/is_utf8.cpp:3553:36: note: remove the ‘< >’
[build] ~/is_utf8/src/is_utf8.cpp:3556:36: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
[build]  3556 |   is_utf8_really_inline simd8<bool>(bool _value) : base8<bool>(splat(_value)) {}
[build]       |                                    ^
[build] ~/is_utf8/src/is_utf8.cpp:3556:36: note: remove the ‘< >’
[build] ~/is_utf8/src/is_utf8.cpp:4068:37: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
[build]  4068 |   is_utf8_really_inline simd16<bool>() : base16() {}
[build]       |                                     ^
[build] ~/is_utf8/src/is_utf8.cpp:4068:37: note: remove the ‘< >’
[build] ~/is_utf8/src/is_utf8.cpp:4069:37: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
[build]  4069 |   is_utf8_really_inline simd16<bool>(const __m128i _value)
[build]       |                                     ^
[build] ~/is_utf8/src/is_utf8.cpp:4069:37: note: remove the ‘< >’
[build] ~/is_utf8/src/is_utf8.cpp:4072:37: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
[build]  4072 |   is_utf8_really_inline simd16<bool>(bool _value)
[build]       |                                     ^
[build] ~/is_utf8/src/is_utf8.cpp:4072:37: note: remove the ‘< >’
```
