### PR TITLE
Fix missing is_utf8Targets.cmake installed file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,12 @@ set(
 mark_as_advanced(IS_UTF8_INSTALL_CMAKEDIR)
 
 install(
+    EXPORT is_utf8Targets
+    DESTINATION "${IS_UTF8_INSTALL_CMAKEDIR}"
+    NAMESPACE is_utf8::
+)
+
+install(
     FILES
     "${PROJECT_BINARY_DIR}/is_utf8-config.cmake"
     "${PROJECT_BINARY_DIR}/is_utf8-config-version.cmake"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ include(GNUInstallDirs)
 include(CTest)
 
 option(IS_UTF8_SANITIZE "Sanitize addresses" OFF)
+option(IS_UTF8_BENCHMARKS "Build benchmarks" ${PROJECT_IS_TOP_LEVEL})
 
 if (NOT CMAKE_BUILD_TYPE)
   message(STATUS "No build type selected, default to Release")
@@ -42,8 +43,9 @@ else()
   message(STATUS "The tests are disabled.")
 endif(BUILD_TESTING)
 
-
-add_subdirectory(benchmarks)
+if (IS_UTF8_BENCHMARKS)
+  add_subdirectory(benchmarks)
+endif()
 
 message(STATUS "Compiling using the C++ standard:" ${CMAKE_CXX_STANDARD})
 # ---- Install rules ----


### PR DESCRIPTION
Attempting to import the library with `find_package` will fail due to `is_utf8Targets.cmake` not being installed

**Before:**
```
# cmake --install build/is_utf8/
-- Install configuration: "Release"
-- Installing: D:/Temp/install/include/is_utf8.h
-- Installing: D:/Temp/install/lib/libis_utf8.a
-- Installing: D:/Temp/install/lib/cmake/is_utf8/is_utf8-config.cmake
-- Installing: D:/Temp/install/lib/cmake/is_utf8/is_utf8-config-version.cmake
```
```
# cmake -DCMAKE_PREFIX_PATH=$(pwd)/install -S sample-is_utf8/ -B build-sample-is_utf8/
-- Building for: Ninja
-- The CXX compiler identification is Clang 22.1.2
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Users/Noe/AppData/Local/Programs/MSYS2/clang64/bin/c++.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Error at D:/Temp/install/lib/cmake/is_utf8/is_utf8-config.cmake:2 (include):
  include could not find requested file:

    D:/Temp/install/lib/cmake/is_utf8/is_utf8Targets.cmake
Call Stack (most recent call first):
  CMakeLists.txt:7 (find_package)


-- Configuring incomplete, errors occurred!
```

**After:**
```
# cmake --install build/is_utf8/
-- Install configuration: "Release"
-- Up-to-date: D:/Temp/install/include/is_utf8.h
-- Up-to-date: D:/Temp/install/lib/libis_utf8.a
-- Up-to-date: D:/Temp/install/lib/cmake/is_utf8/is_utf8Targets.cmake
-- Up-to-date: D:/Temp/install/lib/cmake/is_utf8/is_utf8Targets-release.cmake
-- Up-to-date: D:/Temp/install/lib/cmake/is_utf8/is_utf8-config.cmake
-- Up-to-date: D:/Temp/install/lib/cmake/is_utf8/is_utf8-config-version.cmake
```
```
# cmake -DCMAKE_PREFIX_PATH=$(pwd)/install -S sample-is_utf8/ -B build-sample-is_utf8/
-- Building for: Ninja
-- The CXX compiler identification is Clang 22.1.2
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Users/Noe/AppData/Local/Programs/MSYS2/clang64/bin/c++.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done (0.4s)
-- Generating done (0.0s)
-- Build files have been written to: D:/Temp/build-sample-is_utf8
```

Also added an option to disable benchmarks, as it currently results in `simdutf` files being installed as well